### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/7.llm/ai-agent.ipynb
+++ b/7.llm/ai-agent.ipynb
@@ -18,7 +18,7 @@
     "  - `ollama run mistral`\n",
     "  - `ollama run codellama`\n",
     "- 3.创建conda环境python>3.10\n",
-    "- 4.安装autogen:`pip install pyautogen`\n",
+    "- 4.安装autogen:`pip install ag2`\n",
     "- 5.安装litellama:`pip install litellm`\n",
     "- 6.安装一些依赖包:\n",
     "    - `pip install litellm[proxy]`\n",


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
